### PR TITLE
Fix data races

### DIFF
--- a/client.go
+++ b/client.go
@@ -300,11 +300,13 @@ func (c *client) query(params *QueryParam) error {
 				if inp.sent {
 					continue
 				}
+				inp.ReadLock.Lock()
 				inp.sent = true
 				select {
 				case params.Entries <- inp:
 				default:
 				}
+				inp.ReadLock.Unlock()
 			} else {
 				// Fire off a node specific query
 				m := new(dns.Msg)

--- a/client.go
+++ b/client.go
@@ -22,6 +22,8 @@ type ServiceEntry struct {
 	Info       string
 	InfoFields []string
 
+	ReadLock sync.Mutex
+
 	Addr net.IP // @Deprecated
 
 	hasTXT bool
@@ -257,27 +259,35 @@ func (c *client) query(params *QueryParam) error {
 
 					// Get the port
 					inp = ensureName(inprogress, rr.Hdr.Name)
+					inp.ReadLock.Lock()
 					inp.Host = rr.Target
 					inp.Port = int(rr.Port)
+					inp.ReadLock.Unlock()
 
 				case *dns.TXT:
 					// Pull out the txt
 					inp = ensureName(inprogress, rr.Hdr.Name)
+					inp.ReadLock.Lock()
 					inp.Info = strings.Join(rr.Txt, "|")
 					inp.InfoFields = rr.Txt
 					inp.hasTXT = true
+					inp.ReadLock.Unlock()
 
 				case *dns.A:
 					// Pull out the IP
 					inp = ensureName(inprogress, rr.Hdr.Name)
+					inp.ReadLock.Lock()
 					inp.Addr = rr.A // @Deprecated
 					inp.AddrV4 = rr.A
+					inp.ReadLock.Unlock()
 
 				case *dns.AAAA:
 					// Pull out the IP
 					inp = ensureName(inprogress, rr.Hdr.Name)
+					inp.ReadLock.Lock()
 					inp.Addr = rr.AAAA // @Deprecated
 					inp.AddrV6 = rr.AAAA
+					inp.ReadLock.Unlock()
 				}
 			}
 


### PR DESCRIPTION
There are some data races we are seeing downstream in prysmaticlabs/prysm.

```
==================
WARNING: DATA RACE
Write at 0x00c0002e8058 by goroutine 105:
  github.com/whyrusleeping/mdns.(*client).query()
      external/com_github_whyrusleeping_mdns/client.go:266 +0xb95
  github.com/whyrusleeping/mdns.Query()
      external/com_github_whyrusleeping_mdns/client.go:85 +0xf4
  github.com/libp2p/go-libp2p/p2p/discovery.(*mdnsService).pollForEntries()
      external/com_github_libp2p_go_libp2p/p2p/discovery/mdns.go:137 +0x23d

Previous read at 0x00c0002e8058 by goroutine 107:
  github.com/libp2p/go-libp2p/p2p/discovery.(*mdnsService).handleEntry()
      external/com_github_libp2p_go_libp2p/p2p/discovery/mdns.go:156 +0x25b
  github.com/libp2p/go-libp2p/p2p/discovery.(*mdnsService).pollForEntries.func1()
      external/com_github_libp2p_go_libp2p/p2p/discovery/mdns.go:125 +0x56

Goroutine 105 (running) created at:
  github.com/libp2p/go-libp2p/p2p/discovery.NewMdnsService()
      external/com_github_libp2p_go_libp2p/p2p/discovery/mdns.go:108 +0x6b5
  github.com/prysmaticlabs/prysm/shared/p2p.startmDNSDiscovery()
      shared/p2p/discovery.go:26 +0xc5
  github.com/prysmaticlabs/prysm/shared/p2p.(*Server).Start()
      shared/p2p/service.go:132 +0x1e3
  github.com/prysmaticlabs/prysm/shared/p2p.TestStartDialRelayNodeFails()
      shared/p2p/service_test.go:49 +0x11c
  testing.tRunner()
      GOROOT/src/testing/testing.go:827 +0x162
```

This has to do with writing to in progress service entries while they are being read. I've introduced a `ReadLock` for the service entry so it can be safely read without being mutated. 

This also fixes failures when running `go test . --race`. 