### PR TITLE
client: don't copy the client when logging

### DIFF
--- a/client.go
+++ b/client.go
@@ -163,7 +163,6 @@ func (c *client) Close() error {
 	}
 	c.closed = true
 
-	logf("[INFO] mdns: Closing client %v", *c)
 	close(c.closedCh)
 
 	if c.ipv4UnicastConn != nil {


### PR DESCRIPTION
It copies a lock.